### PR TITLE
Resolve issue with EditorButton not triggering on when button appended to page

### DIFF
--- a/js/admin-foogallery-editor.js
+++ b/js/admin-foogallery-editor.js
@@ -26,7 +26,7 @@
 
 	//hook up the extensions search
 	FOOGALLERY.bindEditorButton = function() {
-		$('.foogallery-modal-trigger').on('click', function(e) {
+		$(document).on('click', '.foogallery-modal-trigger', function(e) {
 			e.preventDefault();
 			//set the active editor
 			FOOGALLERY.activeEditor = $(this).data('editor');


### PR DESCRIPTION
This PR fixes an issue where there's an editor appended to the document after load. An example instance where this will happen is [SiteOrigin Page Builder](https://wordpress.org/plugins/siteorigin-panels/) (and other Page Builder type plugins like Elementor).

Here's a comparison of before:
![](https://i.imgur.com/WXsH0zi.gif)

After change:
![](https://i.imgur.com/Evpe8qm.gif)

Tested widgets being the SiteOrigin Editor widget included in the SiteOrigin Widgets Bundle and Black Studio TinyMCE.