### PR TITLE
Fixed FooGallery cache causes rewrites of options cache on every request.

### DIFF
--- a/freemius/includes/managers/class-fs-option-manager.php
+++ b/freemius/includes/managers/class-fs-option-manager.php
@@ -153,7 +153,7 @@
 
                 $cached = true;
 
-                if ( empty( $this->_options ) ) {
+                if ( false === $this->_options ) {
                     if ( $this->_is_network_storage ) {
                         $this->_options = get_site_option( $option_name );
                     } else if ( $this->_blog_id > 0 ) {


### PR DESCRIPTION
Problem
* Freemius re-sets an option named "fs_cache_843" on every request with an empty array, which causes the total cache of all options to be autoloaded to be regenerated on every single page view.

Cause
* The existing code tries to manage a cache for performance already, but it considers an existing empty array value to need updating. The default value is empty though.

Proposed solution
1. Only update the stored options if there no existing ones yet.