### PR TITLE
Update Dashicons for gallery section icons

### DIFF
--- a/includes/admin/class-gallery-metabox-settings.php
+++ b/includes/admin/class-gallery-metabox-settings.php
@@ -109,8 +109,8 @@ if ( ! class_exists( 'FooGallery_Admin_Gallery_MetaBox_Settings' ) ) {
          * @param string $section_slug
          * @return string
         */
-        function add_section_icons($section_slug) {
-            switch ($section_slug) {
+        function add_section_icons( $section_slug ) {
+            switch ( $section_slug ) {
                 case 'general':
                     return 'dashicons-format-gallery';
                 case 'advanced':

--- a/includes/admin/class-gallery-metabox-settings.php
+++ b/includes/admin/class-gallery-metabox-settings.php
@@ -105,23 +105,24 @@ if ( ! class_exists( 'FooGallery_Admin_Gallery_MetaBox_Settings' ) ) {
 
         /**
          * Returns the Dashicon that can be used in the settings tabs
-         * @param $section_slug
+         *
+         * @param string $section_slug
          * @return string
-         */
-        function add_section_icons( $section_slug ) {
-            switch ( $section_slug ) {
+        */
+        function add_section_icons($section_slug) {
+            switch ($section_slug) {
                 case 'general':
-                    return 'dashicons-format-image';
+                    return 'dashicons-format-gallery';
                 case 'advanced':
-                    return 'dashicons-admin-generic';
+                    return 'dashicons-admin-tools';
                 case 'appearance':
                     return 'dashicons-admin-appearance';
                 case 'video':
-                    return 'dashicons-format-video';
-				case 'hover effects':
-					return 'dashicons-admin-tools';
-				case 'captions':
-					return 'dashicons-testimonial';
+                    return 'dashicons-video-alt3';
+                case 'hover effects':
+                    return 'dashicons-star-filled';
+                case 'captions':
+                    return 'dashicons-editor-quote';
                 case 'paging':
                     return 'dashicons-admin-page';
             }


### PR DESCRIPTION
This pull request updates the Dashicons used in the `add_section_icons()` function for the gallery settings tabs in the plugin. The changes contribute to the plugin in the following ways:

- Improved Visual Representation: By using more relevant Dashicons, such as representing a gallery instead of an image and indicating advanced options or tools, the icons better reflect the purpose and content of each settings section. This enhances the user experience and provides clearer visual cues for navigating the settings.

- Enhanced User Understanding: The updated Dashicons, such as a specific video icon and an icon for special hover effects, contribute to improved user understanding of the respective sections. Users can quickly identify the relevant settings based on the visual representation provided by the icons.

- Consistency and Coherence: The updated Dashicons maintain consistency with the plugin's overall design language and adhere to the established iconography standards. This contributes to a cohesive and visually pleasing user interface.

**screenshots****
Before:
![Before](https://github.com/fooplugins/foogallery/assets/104835999/2d343d00-40b8-4010-b7f6-d230f832df9b)

After:
![After](https://github.com/fooplugins/foogallery/assets/104835999/e5799c10-d454-4cd8-baec-0a244cf1f7a5)

By making these changes, the plugin's gallery settings tabs become more intuitive, user-friendly, and visually appealing, ultimately enhancing the overall user experience within the plugin.
