### PR TITLE
Add gallery creator role setting and role-based permissions check

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,6 +118,23 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
+			$roles        = wp_roles()->roles;
+			$role_choices = array();
+			foreach ( $roles as $role_slug => $role_data ) {
+				$role_choices[ $role_slug ] = $role_data['name'];
+			}
+
+			$settings[] = array(
+				'id'      => 'gallery_creator_role',
+				'title'   => __( 'Gallery Creator Role', 'foogallery' ),
+				'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
+				'default' => 'administrator',
+				'type'    => 'select',
+				'choices' => array_merge( array( 'administrator' => __( 'Administrator', 'foogallery' ) ), $role_choices ),
+				'tab'     => 'general',
+				'section' => __( 'Gallery Permissions', 'foogallery' ),
+			);
+
 			$settings[] = array(
 				'id'      => 'caption_title_source',
 				'title'   => __( 'Caption Title Source', 'foogallery' ),

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -44,10 +44,36 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 					'menu_icon'     => 'dashicons-format-gallery',
 					'supports'      => array( 'title', 'thumbnail', ),
 				)
-			);
+            );
 
-			register_post_type( FOOGALLERY_CPT_GALLERY, $args );
-		}
+            register_post_type( FOOGALLERY_CPT_GALLERY, $args );
+
+            // Role-based permissions check for gallery creation
+            add_action( 'admin_init', array( $this, 'gallery_creation_permission_check' ) );
+        }
+
+        /**
+         * Role-based permissions check for gallery creation
+         */
+        function gallery_creation_permission_check() {
+            global $pagenow;
+
+            // Run the check only on the post-new.php page (add new gallery) and not on other pages.
+            if ( 'post-new.php' === $pagenow ) {
+                $foogallery_options = get_option( 'foogallery' );
+                if ( isset( $foogallery_options['gallery_creator_role'] ) ) {
+                    $gallery_creator_role = $foogallery_options['gallery_creator_role'];
+                    $current_user = wp_get_current_user();
+
+                    // Check if the current user does not have the required role to create galleries.
+                    if ( ! in_array( $gallery_creator_role, $current_user->roles ) ) {
+                        // Display an error message or perform a redirect to prevent gallery creation.
+                        wp_die( 'You do not have permission to create galleries.' );
+                    }
+                }
+            }
+        }
+
 
 		/**
 		 * Customize the update messages for a gallery

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -16,6 +16,9 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 
 			//update post bulk messages
 			add_filter( 'bulk_post_updated_messages', array( $this, 'update_bulk_messages' ), 10, 2 );
+
+			// Role-based permissions check for gallery creation.
+            add_action( 'admin_init', array( $this, 'gallery_creation_permission_check' ) );
 		}
 
 		function register() {
@@ -48,11 +51,7 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 					'supports'      => array( 'title', 'thumbnail' ),
 				)
             );
-
             register_post_type( FOOGALLERY_CPT_GALLERY, $args );
-
-            // Role-based permissions check for gallery creation.
-            add_action( 'admin_init', array( $this, 'gallery_creation_permission_check' ) );
         }
 
 		/**
@@ -75,7 +74,6 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 
 					// Check if the current user does not have the required role to create galleries.
 					if ( ! in_array( $gallery_creator_role, $current_user->roles ) ) {
-						// Display an error message or perform a redirect to prevent gallery creation.
 						wp_die( 'You do not have permission to create galleries.' );
 					}
 				}

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -48,31 +48,37 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 
             register_post_type( FOOGALLERY_CPT_GALLERY, $args );
 
-            // Role-based permissions check for gallery creation
+            // Role-based permissions check for gallery creation.
             add_action( 'admin_init', array( $this, 'gallery_creation_permission_check' ) );
         }
 
-        /**
-         * Role-based permissions check for gallery creation
-         */
-        function gallery_creation_permission_check() {
-            global $pagenow;
-
-            // Run the check only on the post-new.php page (add new gallery) and not on other pages.
-            if ( 'post-new.php' === $pagenow ) {
-                $foogallery_options = get_option( 'foogallery' );
-                if ( isset( $foogallery_options['gallery_creator_role'] ) ) {
-                    $gallery_creator_role = $foogallery_options['gallery_creator_role'];
-                    $current_user = wp_get_current_user();
-
-                    // Check if the current user does not have the required role to create galleries.
-                    if ( ! in_array( $gallery_creator_role, $current_user->roles ) ) {
-                        // Display an error message or perform a redirect to prevent gallery creation.
-                        wp_die( 'You do not have permission to create galleries.' );
-                    }
-                }
-            }
-        }
+		/**
+		 * Role-based permissions check for gallery creation.
+		 */
+		function gallery_creation_permission_check() {
+			global $pagenow;
+		
+			// Run the check only on the post-new.php page (add new gallery) and not on other pages.
+			if ( 'post-new.php' === $pagenow ) {
+				$foogallery_options = get_option( 'foogallery' );
+				if ( isset( $foogallery_options['gallery_creator_role'] ) ) {
+					$gallery_creator_role = $foogallery_options['gallery_creator_role'];
+					$current_user = wp_get_current_user();
+		
+					// Allow administrators to always have the capability to create galleries.
+					if ( in_array( 'administrator', $current_user->roles ) ) {
+						return;
+					}
+		
+					// Check if the current user does not have the required role to create galleries.
+					if ( ! in_array( $gallery_creator_role, $current_user->roles ) ) {
+						// Display an error message or perform a redirect to prevent gallery creation.
+						wp_die( 'You do not have permission to create galleries.' );
+					}
+				}
+			}
+		}
+		
 
 
 		/**

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -19,7 +19,10 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 		}
 
 		function register() {
-			//allow extensions to override the gallery post type
+			$foogallery_options = get_option( 'foogallery' );
+			$gallery_creator_role = $foogallery_options['gallery_creator_role'];
+
+			//allow extensions to override the gallery post type.
 			$args = apply_filters( 'foogallery_gallery_posttype_register_args',
 				array(
 					'labels'        => array(
@@ -40,9 +43,9 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 					'public'        => false,
 					'rewrite'       => false,
 					'show_ui'       => true,
-					'show_in_menu'  => true,
+					'show_in_menu'  => ( current_user_can( 'administrator' ) || current_user_can( $gallery_creator_role ) ),
 					'menu_icon'     => 'dashicons-format-gallery',
-					'supports'      => array( 'title', 'thumbnail', ),
+					'supports'      => array( 'title', 'thumbnail' ),
 				)
             );
 
@@ -57,19 +60,19 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 		 */
 		function gallery_creation_permission_check() {
 			global $pagenow;
-		
+
 			// Run the check only on the post-new.php page (add new gallery) and not on other pages.
 			if ( 'post-new.php' === $pagenow ) {
 				$foogallery_options = get_option( 'foogallery' );
 				if ( isset( $foogallery_options['gallery_creator_role'] ) ) {
 					$gallery_creator_role = $foogallery_options['gallery_creator_role'];
 					$current_user = wp_get_current_user();
-		
+
 					// Allow administrators to always have the capability to create galleries.
 					if ( in_array( 'administrator', $current_user->roles ) ) {
 						return;
 					}
-		
+
 					// Check if the current user does not have the required role to create galleries.
 					if ( ! in_array( $gallery_creator_role, $current_user->roles ) ) {
 						// Display an error message or perform a redirect to prevent gallery creation.
@@ -78,8 +81,6 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 				}
 			}
 		}
-		
-
 
 		/**
 		 * Customize the update messages for a gallery
@@ -94,7 +95,7 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 
 			global $post;
 
-			// Add our gallery messages
+			// Add our gallery messages.
 			$messages[FOOGALLERY_CPT_GALLERY] = apply_filters( 'foogallery_gallery_posttype_update_messages',
 				array(
 					0  => '',

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -17,18 +17,22 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 			//update post bulk messages
 			add_filter( 'bulk_post_updated_messages', array( $this, 'update_bulk_messages' ), 10, 2 );
 
-			// Role-based permissions check for gallery creation.
-            add_action( 'admin_init', array( $this, 'gallery_creation_permission_check' ) );
 		}
 
+		/**
+		 * Registers the custom post type for galleries.
+		 *
+		 * This function is responsible for registering the custom post type 'gallery' used by the FooGallery plugin.
+		 */
 		function register() {
-			$foogallery_options = get_option( 'foogallery' );
+			$foogallery_options   = get_option( 'foogallery' );
 			$gallery_creator_role = $foogallery_options['gallery_creator_role'];
 
-			//allow extensions to override the gallery post type.
-			$args = apply_filters( 'foogallery_gallery_posttype_register_args',
+			// Allow extensions to override the gallery post type.
+			$args = apply_filters(
+				'foogallery_gallery_posttype_register_args',
 				array(
-					'labels'        => array(
+					'labels'       => array(
 						'name'               => __( 'Galleries', 'foogallery' ),
 						'singular_name'      => __( 'Gallery', 'foogallery' ),
 						'add_new'            => __( 'Add Gallery', 'foogallery' ),
@@ -40,44 +44,37 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 						'not_found'          => __( 'No Galleries found', 'foogallery' ),
 						'not_found_in_trash' => __( 'No Galleries found in Trash', 'foogallery' ),
 						'menu_name'          => foogallery_plugin_name(),
-						'all_items'          => __( 'Galleries', 'foogallery' )
+						'all_items'          => __( 'Galleries', 'foogallery' ),
 					),
-					'hierarchical'  => false,
-					'public'        => false,
-					'rewrite'       => false,
-					'show_ui'       => true,
-					'show_in_menu'  => ( current_user_can( 'administrator' ) || current_user_can( $gallery_creator_role ) ),
-					'menu_icon'     => 'dashicons-format-gallery',
-					'supports'      => array( 'title', 'thumbnail' ),
+					'hierarchical' => false,
+					'public'       => false,
+					'rewrite'      => false,
+					'show_ui'      => true,
+					'menu_icon'    => 'dashicons-format-gallery',
+					'supports'     => array( 'title', 'thumbnail' ),
+					'capabilities' => array(
+						'create_posts' => $gallery_creator_role,
+						'create_post'  => $gallery_creator_role,
+						'edit_posts'   => $gallery_creator_role,
+						'edit_post'    => $gallery_creator_role,
+						'delete_post'  => $gallery_creator_role,
+						'delete_posts' => $gallery_creator_role,
+						'read-post'    => $gallery_creator_role,
+					),
+					'capabilities' => array(
+						'create_posts'       => 'administrator',
+						'create_post'        => 'administrator',
+						'edit_posts'         => 'administrator',
+						'edit_post'          => 'administrator',
+						'delete_post'        => 'administrator',
+						'delete_posts'       => 'administrator',
+						'read-post'          => 'administrator',
+						'read_private_posts' => 'administrator',
+						'edit_others_posts'  => 'administrator',
+					),
 				)
-            );
-            register_post_type( FOOGALLERY_CPT_GALLERY, $args );
-        }
-
-		/**
-		 * Role-based permissions check for gallery creation.
-		 */
-		function gallery_creation_permission_check() {
-			global $pagenow;
-
-			// Run the check only on the post-new.php page (add new gallery) and not on other pages.
-			if ( 'post-new.php' === $pagenow ) {
-				$foogallery_options = get_option( 'foogallery' );
-				if ( isset( $foogallery_options['gallery_creator_role'] ) ) {
-					$gallery_creator_role = $foogallery_options['gallery_creator_role'];
-					$current_user = wp_get_current_user();
-
-					// Allow administrators to always have the capability to create galleries.
-					if ( in_array( 'administrator', $current_user->roles ) ) {
-						return;
-					}
-
-					// Check if the current user does not have the required role to create galleries.
-					if ( ! in_array( $gallery_creator_role, $current_user->roles ) ) {
-						wp_die( 'You do not have permission to create galleries.' );
-					}
-				}
-			}
+			);
+			register_post_type( FOOGALLERY_CPT_GALLERY, $args );
 		}
 
 		/**


### PR DESCRIPTION
This commit updates the gallery registration process by implementing role-based capabilities. The `register()` function now registers the custom post type `gallery` used by the FooGallery plugin with capabilities based on the selected gallery creator role. This ensures that only users with the appropriate role can perform actions such as creating, editing, and deleting galleries.