### PR TITLE
Add gallery creator role setting and Restrict custom post type

### DIFF
--- a/extensions/albums/class-posttypes.php
+++ b/extensions/albums/class-posttypes.php
@@ -75,7 +75,7 @@ if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
 					'edit_post'    => $gallery_creator_role,
 					'delete_post'  => $gallery_creator_role,
 					'delete_posts' => $gallery_creator_role,
-					'read-post'    => $gallery_creator_role
+					'read-post'    => $gallery_creator_role,
 				);
 			}
 

--- a/extensions/albums/class-posttypes.php
+++ b/extensions/albums/class-posttypes.php
@@ -1,29 +1,37 @@
 <?php
-/*
+
+/**
  * FooGallery Album Custom Post Types
+ *
+ * @package FooGallery
  */
 
 if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
-
+	/**
+	 * Class FooGallery_Post_Type
+	 *
+	 * Handles the registration and management of custom post types for FooGallery.
+	 */
 	class FooGallery_Albums_PostTypes {
 
-		function __construct() {
-			//register the post types.
+		/**
+		 * Constructor method.
+		 */
+		public function __construct() {
+			// register the post types.
 			add_action( 'init', array( $this, 'register_posttype' ) );
 
-			//update post type messages.
+			// update post type messages.
 			add_filter( 'post_updated_messages', array( $this, 'update_messages' ) );
 
-			//update post bulk messages.
+			// update post bulk messages.
 			add_filter( 'bulk_post_updated_messages', array( $this, 'update_bulk_messages' ), 10, 2 );
 		}
 
 		/**
-		 * Registers the custom post type for albums.
-		 *
-		 * This function is responsible for registering the custom post type 'albums' used by the FooGallery plugin.
+		 * Registers the custom post types.
 		 */
-		function register_posttype() {
+		public function register_posttype() {
 			$album_creator_role   = foogallery_get_setting( 'album_creator_role', 'inherit' );
 			$gallery_creator_role = foogallery_get_setting( 'gallery_creator_role', '' );
 
@@ -94,7 +102,7 @@ if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
 		 *
 		 * @global object $post     The current post object.
 		 *
-		 * @param array   $messages Array of default post updated messages.
+		 * @param array $messages Array of default post updated messages.
 		 *
 		 * @return array $messages Amended array of post updated messages.
 		 */
@@ -102,20 +110,21 @@ if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
 
 			global $post;
 
-			// Add our album messages
-			$messages[FOOGALLERY_CPT_ALBUM] = apply_filters( 'foogallery_album_posttype_update_messages',
+			// Add our album messages.
+			$messages[ FOOGALLERY_CPT_ALBUM ] = apply_filters(
+				'foogallery_album_posttype_update_messages',
 				array(
 					0  => '',
 					1  => __( 'Album updated.', 'foogallery' ),
 					2  => __( 'Album custom field updated.', 'foogallery' ),
 					3  => __( 'Album custom field deleted.', 'foogallery' ),
 					4  => __( 'Album updated.', 'foogallery' ),
-					5  => isset($_GET['revision']) ? sprintf( __( 'Album restored to revision from %s.', 'foogallery' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+					5  => isset( $_GET['revision'] ) ? sprintf( __( 'Album restored to revision from %s.', 'foogallery' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 					6  => __( 'Album published.', 'foogallery' ),
 					7  => __( 'Album saved.', 'foogallery' ),
 					8  => __( 'Album submitted.', 'foogallery' ),
 					9  => sprintf( __( 'Album scheduled for: <strong>%1$s</strong>.', 'foogallery' ), date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ) ),
-					10 => __( 'Album draft updated.', 'foogallery' )
+					10 => __( 'Album draft updated.', 'foogallery' ),
 				)
 			);
 
@@ -131,9 +140,10 @@ if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
 		 *
 		 * @return array mixed            Amended array of bulk updated messages.
 		 */
-		function update_bulk_messages( $bulk_messages, $bulk_counts ) {
+		public function update_bulk_messages( $bulk_messages, $bulk_counts ) {
 
-			$bulk_messages[FOOGALLERY_CPT_ALBUM] = apply_filters( 'foogallery_album_posttype_bulk_update_messages',
+			$bulk_messages[ FOOGALLERY_CPT_ALBUM ] = apply_filters(
+				'foogallery_album_posttype_bulk_update_messages',
 				array(
 					'updated'   => _n( '%s Album updated.', '%s Albums updated.', $bulk_counts['updated'], 'foogallery' ),
 					'locked'    => _n( '%s Album not updated, somebody is editing it.', '%s Albums not updated, somebody is editing them.', $bulk_counts['locked'], 'foogallery' ),

--- a/extensions/albums/class-posttypes.php
+++ b/extensions/albums/class-posttypes.php
@@ -8,43 +8,84 @@ if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
 	class FooGallery_Albums_PostTypes {
 
 		function __construct() {
-			//register the post types
+			//register the post types.
 			add_action( 'init', array( $this, 'register_posttype' ) );
 
-			//update post type messages
+			//update post type messages.
 			add_filter( 'post_updated_messages', array( $this, 'update_messages' ) );
 
-			//update post bulk messages
+			//update post bulk messages.
 			add_filter( 'bulk_post_updated_messages', array( $this, 'update_bulk_messages' ), 10, 2 );
 		}
 
+		/**
+		 * Registers the custom post type for albums.
+		 *
+		 * This function is responsible for registering the custom post type 'albums' used by the FooGallery plugin.
+		 */
 		function register_posttype() {
-			//allow extensions to override the album post type
-			$args = apply_filters( 'foogallery_album_posttype_register_args',
-				array(
-					'labels'        => array(
-						'name'               => __( 'Albums', 'foogallery' ),
-						'singular_name'      => __( 'Album', 'foogallery' ),
-						'add_new'            => __( 'Add Album', 'foogallery' ),
-						'add_new_item'       => __( 'Add New Album', 'foogallery' ),
-						'edit_item'          => __( 'Edit Album', 'foogallery' ),
-						'new_item'           => __( 'New Album', 'foogallery' ),
-						'view_item'          => __( 'View Album', 'foogallery' ),
-						'search_items'       => __( 'Search Albums', 'foogallery' ),
-						'not_found'          => __( 'No Albums found', 'foogallery' ),
-						'not_found_in_trash' => __( 'No Albums found in Trash', 'foogallery' ),
-						'menu_name'          => __( 'Albums', 'foogallery' ),
-						'all_items'          => __( 'Albums', 'foogallery' )
-					),
-					'hierarchical'  => false,
-					'public'        => false,
-					'rewrite'       => false,
-					'show_ui'       => true,
-					'show_in_menu'  => foogallery_admin_menu_parent_slug(),
-					'supports'      => array( 'title' ),
-				)
+			$album_creator_role   = foogallery_get_setting( 'album_creator_role', 'inherit' );
+			$gallery_creator_role = foogallery_get_setting( 'gallery_creator_role', '' );
+
+			$args = array(
+				'labels'       => array(
+					'name'               => __( 'Albums', 'foogallery' ),
+					'singular_name'      => __( 'Album', 'foogallery' ),
+					'add_new'            => __( 'Add Album', 'foogallery' ),
+					'add_new_item'       => __( 'Add New Album', 'foogallery' ),
+					'edit_item'          => __( 'Edit Album', 'foogallery' ),
+					'new_item'           => __( 'New Album', 'foogallery' ),
+					'view_item'          => __( 'View Album', 'foogallery' ),
+					'search_items'       => __( 'Search Albums', 'foogallery' ),
+					'not_found'          => __( 'No Albums found', 'foogallery' ),
+					'not_found_in_trash' => __( 'No Albums found in Trash', 'foogallery' ),
+					'menu_name'          => __( 'Albums', 'foogallery' ),
+					'all_items'          => __( 'Albums', 'foogallery' ),
+				),
+				'hierarchical' => false,
+				'public'       => false,
+				'rewrite'      => false,
+				'show_ui'      => true,
+				'supports'     => array( 'title' ),
 			);
 
+			if ( 'inherit' !== $album_creator_role && '' !== $album_creator_role ) {
+				$args['capabilities'] = array(
+					'create_posts'         => $album_creator_role,
+					'create_post'          => $album_creator_role,
+					'edit_posts'           => $album_creator_role,
+					'edit_post'            => $album_creator_role,
+					'edit_others_posts'    => $album_creator_role,
+					'edit_others_post'     => $album_creator_role,
+					'publish_posts'        => $album_creator_role,
+					'publish_post'         => $album_creator_role,
+					'read_private_posts'   => $album_creator_role,
+					'read_private_post'    => $album_creator_role,
+					'delete_posts'         => $album_creator_role,
+					'delete_post'          => $album_creator_role,
+					'delete_private_posts' => $album_creator_role,
+					'delete_private_post'  => $album_creator_role,
+				);
+			} elseif ( '' !== $gallery_creator_role ) {
+				$args['capabilities'] = array(
+					'create_posts'         => $gallery_creator_role,
+					'create_post'          => $gallery_creator_role,
+					'edit_posts'           => $gallery_creator_role,
+					'edit_post'            => $gallery_creator_role,
+					'edit_others_posts'    => $gallery_creator_role,
+					'edit_others_post'     => $gallery_creator_role,
+					'publish_posts'        => $gallery_creator_role,
+					'publish_post'         => $gallery_creator_role,
+					'read_private_posts'   => $gallery_creator_role,
+					'read_private_post'    => $gallery_creator_role,
+					'delete_posts'         => $gallery_creator_role,
+					'delete_post'          => $gallery_creator_role,
+					'delete_private_posts' => $gallery_creator_role,
+					'delete_private_post'  => $gallery_creator_role,
+				);
+			}
+
+			$args = apply_filters( 'foogallery_album_posttype_register_args', $args );
 			register_post_type( FOOGALLERY_CPT_ALBUM, $args );
 		}
 

--- a/extensions/albums/class-posttypes.php
+++ b/extensions/albums/class-posttypes.php
@@ -63,33 +63,19 @@ if ( ! class_exists( 'FooGallery_Albums_PostTypes' ) ) {
 					'create_post'          => $album_creator_role,
 					'edit_posts'           => $album_creator_role,
 					'edit_post'            => $album_creator_role,
-					'edit_others_posts'    => $album_creator_role,
-					'edit_others_post'     => $album_creator_role,
-					'publish_posts'        => $album_creator_role,
-					'publish_post'         => $album_creator_role,
-					'read_private_posts'   => $album_creator_role,
-					'read_private_post'    => $album_creator_role,
 					'delete_posts'         => $album_creator_role,
 					'delete_post'          => $album_creator_role,
-					'delete_private_posts' => $album_creator_role,
-					'delete_private_post'  => $album_creator_role,
+					'read_post'            => $album_creator_role,
 				);
 			} elseif ( '' !== $gallery_creator_role ) {
 				$args['capabilities'] = array(
-					'create_posts'         => $gallery_creator_role,
-					'create_post'          => $gallery_creator_role,
-					'edit_posts'           => $gallery_creator_role,
-					'edit_post'            => $gallery_creator_role,
-					'edit_others_posts'    => $gallery_creator_role,
-					'edit_others_post'     => $gallery_creator_role,
-					'publish_posts'        => $gallery_creator_role,
-					'publish_post'         => $gallery_creator_role,
-					'read_private_posts'   => $gallery_creator_role,
-					'read_private_post'    => $gallery_creator_role,
-					'delete_posts'         => $gallery_creator_role,
-					'delete_post'          => $gallery_creator_role,
-					'delete_private_posts' => $gallery_creator_role,
-					'delete_private_post'  => $gallery_creator_role,
+					'create_posts' => $gallery_creator_role,
+					'create_post'  => $gallery_creator_role,
+					'edit_posts'   => $gallery_creator_role,
+					'edit_post'    => $gallery_creator_role,
+					'delete_post'  => $gallery_creator_role,
+					'delete_posts' => $gallery_creator_role,
+					'read-post'    => $gallery_creator_role
 				);
 			}
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,26 +118,6 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
-			$roles        = get_editable_roles();
-			$role_choices = array(
-				'' => __( 'No Default', 'foogallery' )
-			);
-
-			foreach ( $roles as $role_slug => $role_data ) {
-				$role_choices[ $role_slug ] = $role_data['name'];
-			}
-
-			$settings[] = array(
-				'id'      => 'gallery_creator_role',
-				'title'   => __( 'Gallery Creator Role', 'foogallery' ),
-				'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
-				'type'    => 'select',
-				'choices' => $role_choices,
-				'tab'     => 'general',
-				'section' => __( 'Gallery Permissions', 'foogallery' ),
-			);
-
-
 			$settings[] = array(
 				'id'      => 'caption_title_source',
 				'title'   => __( 'Caption Title Source', 'foogallery' ),
@@ -179,6 +159,25 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'type'    => 'checkbox',
 				'tab'     => 'general',
 				'section' => __( 'Admin', 'foogallery' )
+			);
+
+			$roles        = get_editable_roles();
+			$role_choices = array(
+				'' => __( 'No Default', 'foogallery' )
+			);
+
+			foreach ( $roles as $role_slug => $role_data ) {
+				$role_choices[ $role_slug ] = $role_data['name'];
+			}
+
+			$settings[] = array(
+				'id'      => 'gallery_creator_role',
+				'title'   => __( 'Gallery Creator Role', 'foogallery' ),
+				'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
+				'type'    => 'select',
+				'choices' => $role_choices,
+				'tab'     => 'general',
+				'section' => __( 'Admin', 'foogallery' ),
 			);
 
 			$settings[] = array(

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
-		       $roles = wp_roles()->roles;
+		       $roles = get_editable_roles();
 		       $role_choices = array();
 	
 		       foreach ($roles as $role_slug => $role_data) {

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -200,6 +200,29 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 
 			//endregion General
 
+			// region Album Tab.
+			$tabs['album'] = __( 'Album', 'foogallery' );
+			$roles        = get_editable_roles();
+			$role_choices = array(
+				'inherit' => __( 'Inherit from gallery creator role', 'foogallery' ),
+			);
+
+			foreach ( $roles as $role_slug => $role_data ) {
+				$role_choices[ $role_slug ] = $role_data['name'];
+			}
+
+			$settings[] = array(
+				'id'      => 'album_creator_role',
+				'title'   => __( 'Album Creator Role', 'foogallery' ),
+				'desc'    => __( 'Set the default role for album creators.', 'foogallery' ),
+				'type'    => 'select',
+				'choices' => $role_choices,
+				'default' => 'inherit',
+				'tab'     => 'album',
+				'section' => __( 'Admin', 'foogallery' ),
+			);
+
+
 			//region Images Tab
 			$tabs['thumb'] = __( 'Images', 'foogallery' );
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,22 +118,22 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
-		       $roles = get_editable_roles();
-		       $role_choices = array();
-	
-		       foreach ($roles as $role_slug => $role_data) {
-			  $role_choices[$role_slug] = $role_data['name'];
-		       }
-	
-		       $settings[] = array(
-			  'id'      => 'gallery_creator_role',
-			  'title'   => __('Gallery Creator Role', 'foogallery'),
-			  'desc'    => __('Select the user role allowed to create galleries', 'foogallery'),   
-			  'type'    => 'select',
-			  'choices' => $role_choices,
-			  'tab'     => 'general',
-			  'section' => __('Gallery Permissions', 'foogallery'),
-		        );
+            $roles        = get_editable_roles();
+            $role_choices = array();
+
+            foreach ( $roles as $role_slug => $role_data ) {
+            	$role_choices[ $role_slug ] = $role_data['name'];
+            }
+
+            $settings[] = array(
+                'id'      => 'gallery_creator_role',
+                'title'   => __( 'Gallery Creator Role', 'foogallery' ),
+                'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
+                'type'    => 'select',
+                'choices' => $role_choices,
+                'tab'     => 'general',
+                'section' => __( 'Gallery Permissions', 'foogallery' ),
+            );
 
 			$settings[] = array(
 				'id'      => 'caption_title_source',

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,22 +118,22 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
-			$roles        = wp_roles()->roles;
-			$role_choices = array();
-			foreach ( $roles as $role_slug => $role_data ) {
-				$role_choices[ $role_slug ] = $role_data['name'];
-			}
-
-			$settings[] = array(
-				'id'      => 'gallery_creator_role',
-				'title'   => __( 'Gallery Creator Role', 'foogallery' ),
-				'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
-				'default' => 'administrator',
-				'type'    => 'select',
-				'choices' => array_merge( array( 'administrator' => __( 'Administrator', 'foogallery' ) ), $role_choices ),
-				'tab'     => 'general',
-				'section' => __( 'Gallery Permissions', 'foogallery' ),
-			);
+		       $roles = wp_roles()->roles;
+		       $role_choices = array();
+	
+		       foreach ($roles as $role_slug => $role_data) {
+			  $role_choices[$role_slug] = $role_data['name'];
+		       }
+	
+		       $settings[] = array(
+			  'id'      => 'gallery_creator_role',
+			  'title'   => __('Gallery Creator Role', 'foogallery'),
+			  'desc'    => __('Select the user role allowed to create galleries', 'foogallery'),   
+			  'type'    => 'select',
+			  'choices' => $role_choices,
+			  'tab'     => 'general',
+			  'section' => __('Gallery Permissions', 'foogallery'),
+		        );
 
 			$settings[] = array(
 				'id'      => 'caption_title_source',

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,22 +118,25 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
-            $roles        = get_editable_roles();
-            $role_choices = array();
+			$roles        = get_editable_roles();
+			$role_choices = array(
+				'' => __( 'No Default', 'foogallery' )
+			);
 
-            foreach ( $roles as $role_slug => $role_data ) {
-            	$role_choices[ $role_slug ] = $role_data['name'];
-            }
+			foreach ( $roles as $role_slug => $role_data ) {
+				$role_choices[ $role_slug ] = $role_data['name'];
+			}
 
-            $settings[] = array(
-                'id'      => 'gallery_creator_role',
-                'title'   => __( 'Gallery Creator Role', 'foogallery' ),
-                'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
-                'type'    => 'select',
-                'choices' => $role_choices,
-                'tab'     => 'general',
-                'section' => __( 'Gallery Permissions', 'foogallery' ),
-            );
+			$settings[] = array(
+				'id'      => 'gallery_creator_role',
+				'title'   => __( 'Gallery Creator Role', 'foogallery' ),
+				'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
+				'type'    => 'select',
+				'choices' => $role_choices,
+				'tab'     => 'general',
+				'section' => __( 'Gallery Permissions', 'foogallery' ),
+			);
+
 
 			$settings[] = array(
 				'id'      => 'caption_title_source',

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -118,6 +118,23 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Gallery Defaults', 'foogallery' )
 			);
 
+			$roles        = wp_roles()->roles;
+			$role_choices = array();
+			foreach ( $roles as $role_slug => $role_data ) {
+				$role_choices[ $role_slug ] = $role_data['name'];
+			}
+
+			$settings[] = array(
+				'id'      => 'gallery_creator_role',
+				'title'   => __( 'Gallery Creator Role', 'foogallery' ),
+				'desc'    => __( 'Select the user role allowed to create galleries', 'foogallery' ),
+				'default' => 'administrator',
+				'type'    => 'select',
+				'choices' => array_merge( array( 'administrator' => __( 'Administrator', 'foogallery' ) ), $role_choices ),
+				'tab'     => 'general',
+				'section' => __( 'Gallery Permissions', 'foogallery' ),
+			);
+
 			$settings[] = array(
 				'id'      => 'caption_title_source',
 				'title'   => __( 'Caption Title Source', 'foogallery' ),

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -201,7 +201,7 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 			// endregion General
 
 			// region Album Tab.
-			$tabs['album'] = __( 'Album', 'foogallery' );
+			$tabs['albums'] = __( 'Albums', 'foogallery' );
 			$roles         = get_editable_roles();
 			$role_choices = array(
 				'inherit' => __( 'Inherit from gallery creator role', 'foogallery' ),
@@ -218,8 +218,7 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'type'    => 'select',
 				'choices' => $role_choices,
 				'default' => 'inherit',
-				'tab'     => 'album',
-				'section' => __( 'Admin', 'foogallery' ),
+				'tab'     => 'albums',
 			);
 			// end of album region.
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -198,11 +198,11 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'section' => __( 'Admin', 'foogallery' )
 			);
 
-			//endregion General
+			// endregion General
 
 			// region Album Tab.
 			$tabs['album'] = __( 'Album', 'foogallery' );
-			$roles        = get_editable_roles();
+			$roles         = get_editable_roles();
 			$role_choices = array(
 				'inherit' => __( 'Inherit from gallery creator role', 'foogallery' ),
 			);
@@ -221,7 +221,7 @@ if ( ! class_exists( 'FooGallery_Admin_Settings' ) ) {
 				'tab'     => 'album',
 				'section' => __( 'Admin', 'foogallery' ),
 			);
-
+			// end of album region.
 
 			//region Images Tab
 			$tabs['thumb'] = __( 'Images', 'foogallery' );

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -24,45 +24,46 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 		 * This function is responsible for registering the custom post type 'gallery' used by the FooGallery plugin.
 		 */
 		function register() {
-			$foogallery_options   = get_option( 'foogallery' );
-			$gallery_creator_role = $foogallery_options['gallery_creator_role'];
-
-			// Allow extensions to override the gallery post type.
-			$args = apply_filters(
-				'foogallery_gallery_posttype_register_args',
-				array(
-					'labels'       => array(
-						'name'               => __( 'Galleries', 'foogallery' ),
-						'singular_name'      => __( 'Gallery', 'foogallery' ),
-						'add_new'            => __( 'Add Gallery', 'foogallery' ),
-						'add_new_item'       => __( 'Add New Gallery', 'foogallery' ),
-						'edit_item'          => __( 'Edit Gallery', 'foogallery' ),
-						'new_item'           => __( 'New Gallery', 'foogallery' ),
-						'view_item'          => __( 'View Gallery', 'foogallery' ),
-						'search_items'       => __( 'Search Galleries', 'foogallery' ),
-						'not_found'          => __( 'No Galleries found', 'foogallery' ),
-						'not_found_in_trash' => __( 'No Galleries found in Trash', 'foogallery' ),
-						'menu_name'          => foogallery_plugin_name(),
-						'all_items'          => __( 'Galleries', 'foogallery' ),
-					),
-					'hierarchical' => false,
-					'public'       => false,
-					'rewrite'      => false,
-					'show_ui'      => true,
-					'menu_icon'    => 'dashicons-format-gallery',
-					'supports'     => array( 'title', 'thumbnail' ),
-					'capabilities' => array(
-						'create_posts' => $gallery_creator_role,
-						'create_post'  => $gallery_creator_role,
-						'edit_posts'   => $gallery_creator_role,
-						'edit_post'    => $gallery_creator_role,
-						'delete_post'  => $gallery_creator_role,
-						'delete_posts' => $gallery_creator_role,
-						'read-post'    => $gallery_creator_role,
-					),
-				)
-			);
-			register_post_type( FOOGALLERY_CPT_GALLERY, $args );
+		    $foogallery_options = get_option( 'foogallery' );
+		    $gallery_creator_role = foogallery_get_setting( 'gallery_creator_role', false );
+		
+		    $args = array(
+		        'labels'       => array(
+		            'name'               => __( 'Galleries', 'foogallery' ),
+		            'singular_name'      => __( 'Gallery', 'foogallery' ),
+		            'add_new'            => __( 'Add Gallery', 'foogallery' ),
+		            'add_new_item'       => __( 'Add New Gallery', 'foogallery' ),
+		            'edit_item'          => __( 'Edit Gallery', 'foogallery' ),
+		            'new_item'           => __( 'New Gallery', 'foogallery' ),
+		            'view_item'          => __( 'View Gallery', 'foogallery' ),
+		            'search_items'       => __( 'Search Galleries', 'foogallery' ),
+		            'not_found'          => __( 'No Galleries found', 'foogallery' ),
+		            'not_found_in_trash' => __( 'No Galleries found in Trash', 'foogallery' ),
+		            'menu_name'          => foogallery_plugin_name(),
+		            'all_items'          => __( 'Galleries', 'foogallery' ),
+		        ),
+		        'hierarchical' => false,
+		        'public'       => false,
+		        'rewrite'      => false,
+		        'show_ui'      => true,
+		        'menu_icon'    => 'dashicons-format-gallery',
+		        'supports'     => array( 'title', 'thumbnail' ),
+		    );
+		
+		    if ( false !== $gallery_creator_role ) {
+		        $args['capabilities'] = array(
+		            'create_posts' => $gallery_creator_role,
+		            'create_post'  => $gallery_creator_role,
+		            'edit_posts'   => $gallery_creator_role,
+		            'edit_post'    => $gallery_creator_role,
+		            'delete_post'  => $gallery_creator_role,
+		            'delete_posts' => $gallery_creator_role,
+		            'read-post'    => $gallery_creator_role,
+		        );
+		    }
+		
+		    $args = apply_filters( 'foogallery_gallery_posttype_register_args', $args );
+		    register_post_type( FOOGALLERY_CPT_GALLERY, $args );
 		}
 
 		/**

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -24,46 +24,46 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 		 * This function is responsible for registering the custom post type 'gallery' used by the FooGallery plugin.
 		 */
 		function register() {
-		    $foogallery_options = get_option( 'foogallery' );
-		    $gallery_creator_role = foogallery_get_setting( 'gallery_creator_role', false );
-		
-		    $args = array(
-		        'labels'       => array(
-		            'name'               => __( 'Galleries', 'foogallery' ),
-		            'singular_name'      => __( 'Gallery', 'foogallery' ),
-		            'add_new'            => __( 'Add Gallery', 'foogallery' ),
-		            'add_new_item'       => __( 'Add New Gallery', 'foogallery' ),
-		            'edit_item'          => __( 'Edit Gallery', 'foogallery' ),
-		            'new_item'           => __( 'New Gallery', 'foogallery' ),
-		            'view_item'          => __( 'View Gallery', 'foogallery' ),
-		            'search_items'       => __( 'Search Galleries', 'foogallery' ),
-		            'not_found'          => __( 'No Galleries found', 'foogallery' ),
-		            'not_found_in_trash' => __( 'No Galleries found in Trash', 'foogallery' ),
-		            'menu_name'          => foogallery_plugin_name(),
-		            'all_items'          => __( 'Galleries', 'foogallery' ),
-		        ),
-		        'hierarchical' => false,
-		        'public'       => false,
-		        'rewrite'      => false,
-		        'show_ui'      => true,
-		        'menu_icon'    => 'dashicons-format-gallery',
-		        'supports'     => array( 'title', 'thumbnail' ),
-		    );
-		
-		    if ( false !== $gallery_creator_role ) {
-		        $args['capabilities'] = array(
-		            'create_posts' => $gallery_creator_role,
-		            'create_post'  => $gallery_creator_role,
-		            'edit_posts'   => $gallery_creator_role,
-		            'edit_post'    => $gallery_creator_role,
-		            'delete_post'  => $gallery_creator_role,
-		            'delete_posts' => $gallery_creator_role,
-		            'read-post'    => $gallery_creator_role,
-		        );
-		    }
-		
-		    $args = apply_filters( 'foogallery_gallery_posttype_register_args', $args );
-		    register_post_type( FOOGALLERY_CPT_GALLERY, $args );
+			$foogallery_options   = get_option( 'foogallery' );
+			$gallery_creator_role = foogallery_get_setting( 'gallery_creator_role', '' );
+
+			$args = array(
+				'labels'       => array(
+					'name'               => __( 'Galleries', 'foogallery' ),
+					'singular_name'      => __( 'Gallery', 'foogallery' ),
+					'add_new'            => __( 'Add Gallery', 'foogallery' ),
+					'add_new_item'       => __( 'Add New Gallery', 'foogallery' ),
+					'edit_item'          => __( 'Edit Gallery', 'foogallery' ),
+					'new_item'           => __( 'New Gallery', 'foogallery' ),
+					'view_item'          => __( 'View Gallery', 'foogallery' ),
+					'search_items'       => __( 'Search Galleries', 'foogallery' ),
+					'not_found'          => __( 'No Galleries found', 'foogallery' ),
+					'not_found_in_trash' => __( 'No Galleries found in Trash', 'foogallery' ),
+					'menu_name'          => foogallery_plugin_name(),
+					'all_items'          => __( 'Galleries', 'foogallery' ),
+				),
+				'hierarchical' => false,
+				'public'       => false,
+				'rewrite'      => false,
+				'show_ui'      => true,
+				'menu_icon'    => 'dashicons-format-gallery',
+				'supports'     => array( 'title', 'thumbnail' ),
+			);
+
+			if ( '' !== $gallery_creator_role ) {
+				$args['capabilities'] = array(
+					'create_posts' => $gallery_creator_role,
+					'create_post'  => $gallery_creator_role,
+					'edit_posts'   => $gallery_creator_role,
+					'edit_post'    => $gallery_creator_role,
+					'delete_post'  => $gallery_creator_role,
+					'delete_posts' => $gallery_creator_role,
+					'read-post'    => $gallery_creator_role,
+				);
+			}
+
+			$args = apply_filters( 'foogallery_gallery_posttype_register_args', $args );
+			register_post_type( FOOGALLERY_CPT_GALLERY, $args );
 		}
 
 		/**

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -18,11 +18,20 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 			add_filter( 'bulk_post_updated_messages', array( $this, 'update_bulk_messages' ), 10, 2 );
 		}
 
+		/**
+		 * Registers the custom post type for galleries.
+		 *
+		 * This function is responsible for registering the custom post type 'gallery' used by the FooGallery plugin.
+		 */
 		function register() {
-			//allow extensions to override the gallery post type
-			$args = apply_filters( 'foogallery_gallery_posttype_register_args',
+			$foogallery_options   = get_option( 'foogallery' );
+			$gallery_creator_role = $foogallery_options['gallery_creator_role'];
+
+			// Allow extensions to override the gallery post type.
+			$args = apply_filters(
+				'foogallery_gallery_posttype_register_args',
 				array(
-					'labels'        => array(
+					'labels'       => array(
 						'name'               => __( 'Galleries', 'foogallery' ),
 						'singular_name'      => __( 'Gallery', 'foogallery' ),
 						'add_new'            => __( 'Add Gallery', 'foogallery' ),
@@ -34,23 +43,30 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 						'not_found'          => __( 'No Galleries found', 'foogallery' ),
 						'not_found_in_trash' => __( 'No Galleries found in Trash', 'foogallery' ),
 						'menu_name'          => foogallery_plugin_name(),
-						'all_items'          => __( 'Galleries', 'foogallery' )
+						'all_items'          => __( 'Galleries', 'foogallery' ),
 					),
-					'hierarchical'  => false,
-					'public'        => false,
-					'rewrite'       => false,
-					'show_ui'       => true,
-					'show_in_menu'  => true,
-					'menu_icon'     => 'dashicons-format-gallery',
-					'supports'      => array( 'title', 'thumbnail', ),
+					'hierarchical' => false,
+					'public'       => false,
+					'rewrite'      => false,
+					'show_ui'      => true,
+					'menu_icon'    => 'dashicons-format-gallery',
+					'supports'     => array( 'title', 'thumbnail' ),
+					'capabilities' => array(
+						'create_posts' => $gallery_creator_role,
+						'create_post'  => $gallery_creator_role,
+						'edit_posts'   => $gallery_creator_role,
+						'edit_post'    => $gallery_creator_role,
+						'delete_post'  => $gallery_creator_role,
+						'delete_posts' => $gallery_creator_role,
+						'read-post'    => $gallery_creator_role,
+					),
 				)
 			);
-
 			register_post_type( FOOGALLERY_CPT_GALLERY, $args );
 		}
 
 		/**
-		 * Customize the update messages for a gallery
+		 * Customize the update messages for a gallery.
 		 *
 		 * @global object $post     The current post object.
 		 *
@@ -62,7 +78,7 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 
 			global $post;
 
-			// Add our gallery messages
+			// Add our gallery messages.
 			$messages[FOOGALLERY_CPT_GALLERY] = apply_filters( 'foogallery_gallery_posttype_update_messages',
 				array(
 					0  => '',

--- a/includes/class-posttypes.php
+++ b/includes/class-posttypes.php
@@ -24,7 +24,6 @@ if ( ! class_exists( 'FooGallery_PostTypes' ) ) {
 		 * This function is responsible for registering the custom post type 'gallery' used by the FooGallery plugin.
 		 */
 		function register() {
-			$foogallery_options   = get_option( 'foogallery' );
 			$gallery_creator_role = foogallery_get_setting( 'gallery_creator_role', '' );
 
 			$args = array(


### PR DESCRIPTION
This commit updates the gallery registration process by implementing role-based capabilities. The register() function now registers the custom post type 'gallery' used by the FooGallery plugin with capabilities based on the selected gallery creator role. This ensures that only users with the appropriate role can perform actions such as creating, editing, and deleting galleries.