### PR TITLE
minor fix: Move thumb engine initialization to init hook

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/foogallery.iml
+++ b/.idea/foogallery.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/foogallery.iml" filepath="$PROJECT_DIR$/.idea/foogallery.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.0">
+    <option name="suggestChangeDefaultLanguageLevel" value="false" />
+  </component>
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/foogallery.php
+++ b/foogallery.php
@@ -111,8 +111,8 @@ if ( function_exists( 'foogallery_fs' ) ) {
 				// init FooPluginBase.
 				$this->init( FOOGALLERY_FILE, FOOGALLERY_SLUG, FOOGALLERY_VERSION, 'FooGallery' );
 
-				// load text domain.
-				$this->load_plugin_textdomain();
+                // Move the text domain loading to init hook
+                add_action('init', array($this, 'load_plugin_textdomain'));
 
 				// setup gallery post type.
 				new FooGallery_PostTypes();

--- a/includes/thumbs/class-foogallery-thumb-manager.php
+++ b/includes/thumbs/class-foogallery-thumb-manager.php
@@ -7,7 +7,8 @@ if ( ! class_exists( 'FooGallery_Thumb_Manager' ) ) {
 	class FooGallery_Thumb_Manager {
 
 		function __construct() {
-			add_action( 'plugins_loaded', array( $this, 'init_active_engine' ) );
+            // Change from plugins_loaded to init
+            add_action( 'init', array( $this, 'init_active_engine' ) );
 		}
 
 		/**


### PR DESCRIPTION
Resolves translation loading error by moving the thumb engine initialization from plugins_loaded to init hook, ensuring translations are loaded at the correct point in the WordPress lifecycle. This resolves a notice message popping up on the latest version of WordPress (6.7.1) 