### PR TITLE
Fix deep linking bug when Master Product is enabled

### DIFF
--- a/extensions/default-templates/shared/js/foogallery.js
+++ b/extensions/default-templates/shared/js/foogallery.js
@@ -7527,7 +7527,8 @@ FooGallery.utils.$, FooGallery.utils, FooGallery.utils.is, FooGallery.utils.fn);
 			self.isError = self.$el.hasClass(cls.error);
 
 			var data = self.$anchor.data();
-			self.id = data.id || self.id;
+			// Enhanced item ID detection - check both data-id and data-attachment-id
+			self.id = self._getItemId(data) || self.id;
 			self.productId = data.productId || self.productId;
 			self.tags = data.tags || self.tags;
 			self.href = data.href || self.$anchor.attr('href') || self.href;
@@ -8200,6 +8201,37 @@ FooGallery.utils.$, FooGallery.utils, FooGallery.utils.is, FooGallery.utils.fn);
 				return "data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%22" + width + "%22%20height=%22" + height + "%22%20viewBox=%220%200%20" + width + "%20" + height + "%22%3E%3C/svg%3E";
 			}
 			return "";
+		},
+		/**
+		 * @summary Enhanced item ID detection that checks both data-id and data-attachment-id attributes.
+		 * @memberof FooGallery.Item#
+		 * @function _getItemId
+		 * @param {object} data - The data object from jQuery's .data() method
+		 * @returns {string|null} The item ID or null if not found
+		 * @private
+		 */
+		_getItemId: function(data) {
+			try {
+				// Check for configured attribute type from template options
+				var config = this.tmpl.opt.state || {};
+				var primaryAttr = config.itemIdAttribute || 'data-attachment-id';
+				
+				// Get the attribute name without 'data-' prefix for jQuery .data() access
+				var primaryKey = primaryAttr.replace('data-', '');
+				var itemId = data[primaryKey];
+				
+				// Fallback to alternative attribute if primary not found
+				if (!itemId) {
+					var fallbackKey = primaryKey === 'id' ? 'attachmentId' : 'id';
+					itemId = data[fallbackKey];
+				}
+				
+				return itemId || null;
+			} catch (e) {
+				console.warn('FooGallery: Error getting item ID', e);
+				// Final fallback to original behavior
+				return data.id || data.attachmentId || null;
+			}
 		},
 		/**
 		 * @summary Gets the type specific CSS class for the item.

--- a/pro/includes/class-foogallery-pro-advanced-gallery-settings.php
+++ b/pro/includes/class-foogallery-pro-advanced-gallery-settings.php
@@ -80,6 +80,9 @@ if ( ! class_exists( 'FooGallery_Pro_Advanced_Gallery_Settings' ) ) {
 
 				$state_mask = foogallery_gallery_template_setting( 'state_mask', 'foogallery-{id}' );
 				$options['state']['mask'] = $state_mask;
+				
+				// Pass item ID attribute setting to JavaScript for enhanced compatibility
+				$options['state']['itemIdAttribute'] = foogallery_get_setting( 'attachment_id_attribute', 'data-attachment-id' );
 			}
 
 			return $options;

--- a/pro/includes/woocommerce/class-foogallery-pro-woocommerce-master-product.php
+++ b/pro/includes/woocommerce/class-foogallery-pro-woocommerce-master-product.php
@@ -301,13 +301,22 @@ if ( ! class_exists( 'FooGallery_Pro_Woocommerce_Master_Product' ) ) {
 		 * @return mixed
 		 */
 		public function adjust_attachment_link_data_attributes( $attr, $args, $foogallery_attachment ) {
-			$product_id = $this->get_master_product_id_from_current_gallery();
-			if ( $product_id > 0 ) {
-				// The data-attachment-id attribute does not work with master products, so we need to make sure it is data-id
-				if ( array_key_exists( 'data-attachment-id', $attr ) ) {
-					unset( $attr[ 'data-attachment-id' ] );
-					$attr[ 'data-id' ] = $foogallery_attachment->ID;
+			try {
+				$product_id = $this->get_master_product_id_from_current_gallery();
+				if ( $product_id > 0 ) {
+					// Get the validated global setting for item ID attribute
+					$item_id_attribute = $this->get_item_id_attribute_setting();
+					
+					// Only modify attributes if global setting requires data-id
+					if ( $item_id_attribute === 'data-id' && array_key_exists( 'data-attachment-id', $attr ) ) {
+						unset( $attr[ 'data-attachment-id' ] );
+						$attr[ 'data-id' ] = $foogallery_attachment->ID;
+					}
+					// Otherwise preserve existing attribute type (data-attachment-id)
 				}
+			} catch ( Exception $e ) {
+				error_log( 'FooGallery Master Product: Error adjusting attachment link data attributes: ' . $e->getMessage() );
+				// Return original attributes on error to ensure functionality continues
 			}
 
 			return $attr;
@@ -1102,6 +1111,28 @@ if ( ! class_exists( 'FooGallery_Pro_Woocommerce_Master_Product' ) ) {
 
             $query['s'] = $query_vars['foogallery_master_product_search'];
             return $query;
+        }
+
+        /**
+         * Helper method to get the item ID attribute setting with validation
+         *
+         * @return string The validated item ID attribute ('data-attachment-id' or 'data-id')
+         */
+        private function get_item_id_attribute_setting() {
+            try {
+                $item_id_attribute = foogallery_get_setting( 'attachment_id_attribute', 'data-attachment-id' );
+                
+                // Validate setting value and fallback to default if invalid
+                if ( !in_array( $item_id_attribute, ['data-attachment-id', 'data-id'] ) ) {
+                    error_log( 'FooGallery Master Product: Invalid item_id_attribute setting value: ' . $item_id_attribute . '. Falling back to default.' );
+                    $item_id_attribute = 'data-attachment-id';
+                }
+                
+                return $item_id_attribute;
+            } catch ( Exception $e ) {
+                error_log( 'FooGallery Master Product: Error getting item ID attribute setting: ' . $e->getMessage() );
+                return 'data-attachment-id'; // Safe fallback
+            }
         }
 	}
 }


### PR DESCRIPTION
## Problem
Deep linking URLs don't open the correct image in lightbox when Master Product is enabled.

## Root Cause
Master Product was forcing `data-attachment-id` to `data-id` conversion, ignoring the global "Item ID Attribute" setting.

## Solution
- Master Product now respects the global `attachment_id_attribute` setting
- Enhanced JavaScript to support both attribute types
- Added error handling and maintains backward compatibility

## Files Changed
- `pro/includes/woocommerce/class-foogallery-pro-woocommerce-master-product.php`
- `pro/includes/class-foogallery-pro-advanced-gallery-settings.php`
- `extensions/default-templates/shared/js/foogallery.js`
