### PR TITLE
Fix typo in custom captions demo link

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -109,7 +109,7 @@ There are 3 PRO plans available, that will work with any budget:
 	*   Numbered pagination - [demo](https://fooplugins.com/foogallery-wordpress-gallery-plugin/pagination/#numbered)
 	*   "Load More" pagination - [demo](https://fooplugins.com/foogallery-wordpress-gallery-plugin/pagination/#load-more)
 	*   Infinite scroll image gallery - [demo](https://fooplugins.com/foogallery-wordpress-gallery-plugin/pagination/#infinite-scroll)
-*	Advanced Custom Captions - [demo](hhttps://fooplugins.com/foogallery-wordpress-gallery-plugin/custom-captions/)
+*	Advanced Custom Captions - [demo](https://fooplugins.com/foogallery-wordpress-gallery-plugin/custom-captions/)
 *	EXIF metadata gallery - [demo](https://fooplugins.com/foogallery-wordpress-gallery-plugin/exif-data/)
 *   Bulk Copy Gallery Settings - [more info](https://fooplugins.com/bulk-copy-foogallery-pro/)
 *	Deeplinking support for pages and filters


### PR DESCRIPTION
## Summary
- fix malformed URL in README for advanced custom captions demo

## Testing
- `npx wp-scripts lint-js`
- `npx wp-scripts lint-style`
- `vendor/bin/phpcs --standard=WordPress .` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a048edc06483248b961c78368de830